### PR TITLE
refactor: avoid nullish coalescing operator (??)

### DIFF
--- a/tests/fixtures-class/non-standard-template-literals/__snapshots__/auto-migrate.expected/template.marko
+++ b/tests/fixtures-class/non-standard-template-literals/__snapshots__/auto-migrate.expected/template.marko
@@ -1,3 +1,6 @@
+static function _toString(value) {
+  return value == null ? "" : value;
+}
 static const fromStatic = "${STATIC}";
 $ const fromScriptlet = "${SCRIPLET}";
 $ const a = 1;
@@ -26,12 +29,12 @@ $ const c = 3;
   ${`abc${`d${"}"}e`}f`}
 </div>
 <div id="h">
-  ${`abc${c ?? ""}`}
+  ${`abc${_toString(c)}`}
 </div>
 <div id="i">
-  ${`abc${{
+  ${`abc${_toString({
     x: 1
-  }.missing ?? ""}def`}
+  }.missing)}def`}
 </div>
 $ const handler = console.log;
 <button onClick(handler)/>

--- a/tests/fixtures-class/non-standard-template-literals/__snapshots__/dom.expected/template.js
+++ b/tests/fixtures-class/non-standard-template-literals/__snapshots__/dom.expected/template.js
@@ -2,6 +2,9 @@ import { t as _t } from "marko/src/runtime/vdom/index.js";
 const _marko_componentType = "<fixture-dir>/template.marko",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
+function _toString(value) {
+  return value == null ? "" : value;
+}
 const fromStatic = "${STATIC}";
 import _marko_class_merge from "marko/src/runtime/helpers/class-value.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
@@ -56,14 +59,14 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.be("div", {
     "id": "h"
   }, "8", _component, null, 1);
-  out.t(`abc${c ?? ""}`, _component);
+  out.t(`abc${_toString(c)}`, _component);
   out.ee();
   out.be("div", {
     "id": "i"
   }, "9", _component, null, 1);
-  out.t(`abc${{
+  out.t(`abc${_toString({
     x: 1
-  }.missing ?? ""}def`, _component);
+  }.missing)}def`, _component);
   out.ee();
   const handler = console.log;
   out.e("button", null, "10", _component, 0, 0, {

--- a/tests/fixtures-class/non-standard-template-literals/__snapshots__/html.expected/template.js
+++ b/tests/fixtures-class/non-standard-template-literals/__snapshots__/html.expected/template.js
@@ -2,6 +2,9 @@ import { t as _t } from "marko/src/runtime/html/index.js";
 const _marko_componentType = "<fixture-dir>/template.marko",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
+function _toString(value) {
+  return value == null ? "" : value;
+}
 const fromStatic = "${STATIC}";
 import _marko_class_merge from "marko/src/runtime/helpers/class-value.js";
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
@@ -37,12 +40,12 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.w("abcd}ef");
   out.w("</div>");
   out.w("<div id=h>");
-  out.w(_marko_escapeXml(`abc${c ?? ""}`));
+  out.w(_marko_escapeXml(`abc${_toString(c)}`));
   out.w("</div>");
   out.w("<div id=i>");
-  out.w(_marko_escapeXml(`abc${{
+  out.w(_marko_escapeXml(`abc${_toString({
     x: 1
-  }.missing ?? ""}def`));
+  }.missing)}def`));
   out.w("</div>");
   const handler = console.log;
   out.w(`<button${_marko_props(out, _componentDef, {

--- a/tests/fixtures-widget/assign-tag/__snapshots__/auto-migrate.expected/template.marko
+++ b/tests/fixtures-widget/assign-tag/__snapshots__/auto-migrate.expected/template.marko
@@ -1,7 +1,10 @@
+static function _toString(value) {
+  return value == null ? "" : value;
+}
 $ var firstName = "John";
 $ var lastName = "Smith";
 $ var fullName;
-$ fullName = `${firstName ?? ""} ${lastName ?? ""}`;
+$ fullName = `${_toString(firstName)} ${_toString(lastName)}`;
 <div>
   ${fullName}
 </div>

--- a/tests/fixtures-widget/assign-tag/__snapshots__/dom.expected/template.js
+++ b/tests/fixtures-widget/assign-tag/__snapshots__/dom.expected/template.js
@@ -2,6 +2,9 @@ import { t as _t } from "marko/src/runtime/vdom/index.js";
 const _marko_componentType = "<fixture-dir>/template.marko",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
+function _toString(value) {
+  return value == null ? "" : value;
+}
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
 _marko_registerComponent(_marko_componentType, () => _marko_template);
@@ -10,7 +13,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   var firstName = "John";
   var lastName = "Smith";
   var fullName;
-  fullName = `${firstName ?? ""} ${lastName ?? ""}`;
+  fullName = `${_toString(firstName)} ${_toString(lastName)}`;
   out.be("div", null, "0", _component, null, 0);
   out.t(fullName, _component);
   out.ee();

--- a/tests/fixtures-widget/assign-tag/__snapshots__/html.expected/template.js
+++ b/tests/fixtures-widget/assign-tag/__snapshots__/html.expected/template.js
@@ -2,6 +2,9 @@ import { t as _t } from "marko/src/runtime/html/index.js";
 const _marko_componentType = "<fixture-dir>/template.marko",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
+function _toString(value) {
+  return value == null ? "" : value;
+}
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
@@ -9,7 +12,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   var firstName = "John";
   var lastName = "Smith";
   var fullName;
-  fullName = `${firstName ?? ""} ${lastName ?? ""}`;
+  fullName = `${_toString(firstName)} ${_toString(lastName)}`;
   out.w("<div>");
   out.w(_marko_escapeXml(fullName));
   out.w("</div>");

--- a/tests/fixtures-widget/var-tag/__snapshots__/auto-migrate.expected/template.marko
+++ b/tests/fixtures-widget/var-tag/__snapshots__/auto-migrate.expected/template.marko
@@ -1,8 +1,11 @@
+static function _toString(value) {
+  return value == null ? "" : value;
+}
 $ var truthy = true;
 $ var falsey = false;
 $ var firstName = "John";
 $ var lastName = "Smith";
-$ var fullName = `${firstName ?? ""} ${lastName ?? ""}`;
+$ var fullName = `${_toString(firstName)} ${_toString(lastName)}`;
 $ if (truthy) {
   var optionalTrue = "a";
 }

--- a/tests/fixtures-widget/var-tag/__snapshots__/dom.expected/template.js
+++ b/tests/fixtures-widget/var-tag/__snapshots__/dom.expected/template.js
@@ -2,6 +2,9 @@ import { t as _t } from "marko/src/runtime/vdom/index.js";
 const _marko_componentType = "<fixture-dir>/template.marko",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
+function _toString(value) {
+  return value == null ? "" : value;
+}
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
 _marko_registerComponent(_marko_componentType, () => _marko_template);
@@ -11,7 +14,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   var falsey = false;
   var firstName = "John";
   var lastName = "Smith";
-  var fullName = `${firstName ?? ""} ${lastName ?? ""}`;
+  var fullName = `${_toString(firstName)} ${_toString(lastName)}`;
   if (truthy) {
     var optionalTrue = "a";
   }

--- a/tests/fixtures-widget/var-tag/__snapshots__/html.expected/template.js
+++ b/tests/fixtures-widget/var-tag/__snapshots__/html.expected/template.js
@@ -2,6 +2,9 @@ import { t as _t } from "marko/src/runtime/html/index.js";
 const _marko_componentType = "<fixture-dir>/template.marko",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
+function _toString(value) {
+  return value == null ? "" : value;
+}
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
@@ -10,7 +13,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   var falsey = false;
   var firstName = "John";
   var lastName = "Smith";
-  var fullName = `${firstName ?? ""} ${lastName ?? ""}`;
+  var fullName = `${_toString(firstName)} ${_toString(lastName)}`;
   if (truthy) {
     var optionalTrue = "a";
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Avoids the usage of the nullish coalescing operator (??) 

**Old**
```marko
<div class=`${value ?? ""}`/>
```

**New**
```marko
static function _toString(value) {
  return value == null ? "" : value;
}

<div class=`${_toString(value)}`/>
```

## Motivation and Context

As this is a compat layer for applications that existed before `??` was part of the language, there have been instances where existing application dependencies (older versions of `babylon` for instance) don't support the new syntax.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
